### PR TITLE
Don't expose Mongo Atlas credentials on .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 PORT=8080
 MONGO_USER=wenega
-MONGO_PASSWORD=8snAAJgUK@7u6@g
+MONGO_PASSWORD=[PASSSWORD-HERE]
 MONGO_DB=listadepessoas
-MONGO_URL_CONNECT=mongodb+srv://wenega:8snAAJgUK@7u6@g@cluster0.gobcz.mongodb.net/listadepessoas?retryWrites=true&w=majority
+MONGO_URL_CONNECT=mongodb://mongo-url-here


### PR DESCRIPTION
This commit removes existent Mongo Atlas username and password from this repository. These credentials access has been revoked.

-----

Obs: Olá @wenegawama, tudo bem? Cuidado ao fazer commits de dados sensíveis como chaves de API/senhas para acesso a serviços em nuvem, como o Mongo Atlas. Mesmo que o seu `.env` apenas dê acesso a um banco de dados de demonstração, isso pode ser considerado como uma falha de segurança e um possível alvo para usuários mal intencionados.

Recomendações: adicionar o `.env` no `.gitignore`, deixando só o `.env.exemplo` no repositório, documentando no README sobre o uso do arquivo e a necessidade de preencher com os devidos valores.

Atualização: recomendo fortemente que você atualize a senha do usuário cadastrado associado a sua conta do Mongo Atlas. Ainda consegui ter acesso ao seu banco de dados.